### PR TITLE
Fix maxListeners option not supporting 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+
+* fix `maxListeners` option not supporting `0` as value (#84)
+
 ## [1.1.9](https://github.com/pustovitDmytro/winston-array-transport/compare/v1.1.8...v1.1.9) (2022-02-28)
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,15 @@ import { MESSAGE } from './constants';
 export default class ArrayTransport extends Transport {
     constructor(options = {}) {
         super(options);
+        const maxListeners = Number.isInteger(options.maxListeners) ? options.maxListeners : defaultMaxListeners;
+
         this.name = options.name || this.constructor.name;
         this.eol = options.eol || os.EOL;
         this.array = options.array || [];
         this.levels = options.levels || {};
         this.parser = options.parser || options.json && defaultParserJSON || defaultParser;
         this.limit = options.limit;
-        this.setMaxListeners(options.maxListeners || defaultMaxListeners);
+        this.setMaxListeners(maxListeners);
     }
 
     log(info, callback) {

--- a/tests/package/configurations.test.js
+++ b/tests/package/configurations.test.js
@@ -45,3 +45,25 @@ test('limit amount of elements in array', function () {
 
     assert.deepEqual(array, [ 96, 97, 98, 99, 100 ].map(i => `{"level":"info","message":${i}}`));
 });
+
+test('default Transport maxListeners', function () {
+    const array = [];
+    const logger = createLogger({
+        level      : 'debug',
+        format     : format.json(),
+        transports : [ new transport({ array, limit: 5 }) ]
+    });
+
+    assert.equal(logger._readableState.pipes._maxListeners, 30);
+});
+
+test('set Transport maxListeners as 0', function () {
+    const array = [];
+    const logger = createLogger({
+        level      : 'debug',
+        format     : format.json(),
+        transports : [ new transport({ array, limit: 5, maxListeners: 0 }) ]
+    });
+
+    assert.equal(logger._readableState.pipes._maxListeners, 0);
+});


### PR DESCRIPTION
Check if maxListeners option is a Number before setting default value instead of using a "truthy" comparison. This allows to give a `0` value to the option, which [in Nodejs is a value that can be used to indicate an unlimited number of listeners.](https://nodejs.org/api/events.html#emittersetmaxlistenersn)

closes #84

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pustovitdmytro/winston-array-transport/85)
<!-- Reviewable:end -->
